### PR TITLE
feat: add support for specifying shared blocks on agent create

### DIFF
--- a/memgpt/client/client.py
+++ b/memgpt/client/client.py
@@ -67,6 +67,7 @@ class AbstractClient(object):
         human: Optional[str] = None,
         embedding_config: Optional[EmbeddingConfig] = None,
         llm_config: Optional[LLMConfig] = None,
+        memory: Optional[Memory] = None,
     ) -> AgentState:
         """Create a new agent with the specified configuration."""
         raise NotImplementedError

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -422,6 +422,7 @@ def run_agent_loop(
                 skip_verify=no_verify,
                 stream=stream,
                 inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
+                ms=ms,
             )
 
             agent.save_agent(memgpt_agent, ms)

--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -424,6 +424,7 @@ def run_agent_loop(
                 inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
             )
 
+            agent.save_agent(memgpt_agent, ms)
             skip_next_user_input = False
             if token_warning:
                 user_message = system.get_token_limit_warning()

--- a/memgpt/metadata.py
+++ b/memgpt/metadata.py
@@ -500,7 +500,16 @@ class MetadataStore:
     def create_block(self, block: Block):
         with self.session_maker() as session:
             # TODO: fix?
-            if session.query(BlockModel).filter(BlockModel.name == block.name).filter(BlockModel.user_id == block.user_id).count() > 0:
+            # we are only validating that more than one template block
+            # with a given name doesn't exist.
+            if (
+                session.query(BlockModel)
+                .filter(BlockModel.name == block.name)
+                .filter(BlockModel.user_id == block.user_id)
+                .filter(BlockModel.template == True)
+                .count()
+                > 0
+            ):
                 raise ValueError(f"Block with name {block.name} already exists")
             session.add(BlockModel(**vars(block)))
             session.commit()

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -410,6 +410,7 @@ class SyncServer(LockingServer):
                 return_dicts=False,
                 stream=token_streaming,
                 timestamp=timestamp,
+                ms=self.ms,
             )
             step_count += 1
             total_usage += usage
@@ -784,6 +785,11 @@ class SyncServer(LockingServer):
                 # gpt-3.5-turbo tends to omit inner monologue, relax this requirement for now
                 first_message_verify_mono=True if (llm_config.model is not None and "gpt-4" in llm_config.model) else False,
             )
+            # rebuilding agent memory on agent create in case shared memory blocks
+            # were specified in the new agent's memory config. we're doing this for two reasons:
+            # 1. if only the ID of the shared memory block was specified, we can fetch its most recent value
+            # 2. if the shared block state changed since this agent initialization started, we can be sure to have the latest value
+            agent.rebuild_memory(force=True, ms=self.ms)
             # FIXME: this is a hacky way to get the system prompts injected into agent into the DB
             # self.ms.update_agent(agent.agent_state)
         except Exception as e:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
This PR adds support for creating agents with shared memory blocks. It depends on this [PR](https://github.com/cpacker/MemGPT/pull/1622) which adds support for persisting agent blocks on each core memory update.

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?
You can test by creating an agent with existing block IDs and then validating that those existing block records are updated. There is an example of this in the tests/test_new_client.py file.

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

Yes, there is a test added for this. 

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).
n/a

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.
n/a

**Additional context**
Add any other context or screenshots about the PR here.

There is some more followup work that would ideally happen here. Some examples:
* documentation for how to specify shared memory blocks
* characterizing / documenting what happens if you have two agents accessing the same block
* cleanup of persisted blocks that are no longer referenced by an active (or existing) agent and are unlikely to be used again
* updating the get_blocks functionality to make sure we return shared blocks when users would like to actually created shared agent blocks.
* centralizing how blocks are made and manipulated so we don't have inconsistent validation logic
