### PR TITLE
feat: update shared memory block data on create and on each step

### DIFF
--- a/memgpt/main.py
+++ b/memgpt/main.py
@@ -422,6 +422,7 @@ def run_agent_loop(
                 skip_verify=no_verify,
                 stream=stream,
                 inner_thoughts_in_kwargs=inner_thoughts_in_kwargs,
+                ms=ms,
             )
 
             agent.save_agent(memgpt_agent, ms)

--- a/memgpt/server/server.py
+++ b/memgpt/server/server.py
@@ -410,6 +410,7 @@ class SyncServer(LockingServer):
                 return_dicts=False,
                 stream=token_streaming,
                 timestamp=timestamp,
+                ms=self.ms,
             )
             step_count += 1
             total_usage += usage
@@ -784,6 +785,11 @@ class SyncServer(LockingServer):
                 # gpt-3.5-turbo tends to omit inner monologue, relax this requirement for now
                 first_message_verify_mono=True if (llm_config.model is not None and "gpt-4" in llm_config.model) else False,
             )
+            # rebuilding agent memory on agent create in case shared memory blocks
+            # were specified in the new agent's memory config. we're doing this for two reasons:
+            # 1. if only the ID of the shared memory block was specified, we can fetch its most recent value
+            # 2. if the shared block state changed since this agent initialization started, we can be sure to have the latest value
+            agent.rebuild_memory(force=True, ms=self.ms)
             # FIXME: this is a hacky way to get the system prompts injected into agent into the DB
             # self.ms.update_agent(agent.agent_state)
         except Exception as e:


### PR DESCRIPTION
**Please describe the purpose of this pull request.**
New feature! This updates the agents on create and on each step to update their internal memory if they are using shared memory blocks. Previously shared blocks could be used, but if two agents were interacting with the same set of blocks they would not be aware of any changes made by one another.

**How to test**
How can we test your PR during review? What commands should we run? What outcomes should we expect?

Added a test and double checked the CLI worked as expected to create agents and update memory.

**Have you tested this PR?**
Have you tested the latest commit on the PR? If so please provide outputs from your tests.

Ye, see the test file.

**Related issues or PRs**
Please link any related GitHub [issues](https://github.com/cpacker/MemGPT/issues) or [PRs](https://github.com/cpacker/MemGPT/pulls).

n/a

**Is your PR over 500 lines of code?**
If so, please break up your PR into multiple smaller PRs so that we can review them quickly, or provide justification for its length.


n/a

**Additional context**
Add any other context or screenshots about the PR here.

see parent PR!